### PR TITLE
Improve ParametricEQ compatibility

### DIFF
--- a/src/utils/VdcProjectManager.cpp
+++ b/src/utils/VdcProjectManager.cpp
@@ -551,13 +551,13 @@ DeflatedBiquad VdcProjectManager::parseParametricEqLine(const QString& str){
         return DeflatedBiquad();
 
     QRegularExpression re
-            (R"(Filter\s\d+[\s\S][^PK]*PK\s+Fc\s+(?<hz>\d+)\s*Hz\s*Gain\s*(?<gain>-?\d*.?\d+)\s*dB\s*Q\s*(?<q>-?\d*.?\d+))");
+            (R"(Filter\s+\d+[\s\S][^PK]*PK\s+Fc\s+(?<hz>\d+(?:\.\d+)?)\s*Hz\s*Gain\s*(?<gain>-?\d*.?\d+)\s*dB\s*Q\s*(?<q>-?\d*.?\d+))");
     QRegularExpressionMatch match = re.match(str);
     if(!match.hasMatch())
         return DeflatedBiquad();
 
     bool freqOk, gainOk, qOk;
-    int freq = match.captured("hz").toInt(&freqOk);
+    int freq = (int)match.captured("hz").toDouble(&freqOk);
     double gain = match.captured("gain").toDouble(&gainOk);
     double q = match.captured("q").toDouble(&qOk);
 


### PR DESCRIPTION
- Improve ParametricEQ regular expression
  - Allow multi-space after _Filter_
  - Allow decimal values for _hz_ capture group
- Handle parsing of decimal frequency values
- This allows direct import of REW filters when exported as text

##### TEST CASE - Sample REW filter
```
Filter Settings file

Room EQ V5.20
Dated: Sep 22, 2021 7:35:47 PM

Notes:

Equaliser: Generic
AVG
Filter  1: ON  PK       Fc   28.55 Hz  Gain  -4.30 dB  Q  4.914
Filter  2: ON  PK       Fc   48.15 Hz  Gain  -3.70 dB  Q  4.879
Filter  3: ON  PK       Fc   92.90 Hz  Gain   3.80 dB  Q  1.000
Filter  4: ON  PK       Fc   278.0 Hz  Gain -10.70 dB  Q  1.792
Filter  5: ON  PK       Fc    1549 Hz  Gain  -5.90 dB  Q  1.000
Filter  6: ON  PK       Fc   13541 Hz  Gain  -5.10 dB  Q  1.739
Filter  7: ON  PK       Fc   17234 Hz  Gain  -6.80 dB  Q  3.138
Filter  8: ON  None   
Filter  9: ON  None   
Filter 10: ON  None   
Filter 11: ON  None   
Filter 12: ON  None   
Filter 13: ON  None   
Filter 14: ON  None   
Filter 15: ON  None   
Filter 16: ON  None   
Filter 17: ON  None   
Filter 18: ON  None   
Filter 19: ON  None   
Filter 20: ON  None   
Filter 21: ON  None   
Filter 25: ON  None   
```