### PR TITLE
Fix build on Fedora and update readme for Fedora specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Install dependencies (Arch)
 
     sudo pacman -S qt5-base 
 
+Install dependencies (Fedora)
+
+    sudo dnf install git gcc-c++ make qt5-qtbase-devel mesa-libGL-dev
+
 Clone this repository
 
     git clone --recurse-submodules https://github.com/ThePBone/DDCToolbox
@@ -183,6 +187,11 @@ Compile sources
 
 You should now be able to execute it:
 
+    ./DDCToolbox
+
+Or:
+
+    cd src
     ./DDCToolbox
 
 #### Optional: Installation and shortcut

--- a/src/3rdparty/libMultivariateOpt/libgenmath/rand_c.c
+++ b/src/3rdparty/libMultivariateOpt/libgenmath/rand_c.c
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "rand_c.h"
 #include "interpolation2.h"
+
+extern void sort(double x_data[], const unsigned int xSize, unsigned int idx_data[]);
+
 static const double tbl1[257] = { 0.0, 0.215241895984875, 0.286174591792068,
   0.335737519214422, 0.375121332878378, 0.408389134611989, 0.43751840220787,
   0.46363433679088, 0.487443966139235, 0.50942332960209, 0.529909720661557,


### PR DESCRIPTION
Fix issues listed in https://github.com/timschneeb/DDCToolbox/issues/19 :

- Installation of dependencies on Fedora is not documented
- The make failed with an error message
- The resulting binary is in `src` while the doc tells me to expect it in the root of the repo

I used Gemini and Claude to work out the changes